### PR TITLE
Add Nasdaq101 and Crypto Flow Studio projects to index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1348,6 +1348,20 @@
                 imageUrl: 'https://placehold.co/600x400/14b8a6/0f172a?text=Prompt+Optimizer',
                 demoUrl: 'https://gemini.google.com/share/beae617d4032',
                 demoUrl2: 'https://promptgen-gules.vercel.app'
+            },
+            {
+                id: 'proj11',
+                title: '나스닥101문',
+                description: '나스닥 관련 핵심 내용을 101문답 형식으로 학습할 수 있는 웹 앱입니다.',
+                imageUrl: 'https://placehold.co/600x400/14b8a6/0f172a?text=Nasdaq+101',
+                demoUrl: 'https://service-101-lite-576760788290.us-west1.run.app/'
+            },
+            {
+                id: 'proj12',
+                title: '크립토 플로우 스튜디오',
+                description: '비트코인, 비트코인 도미넌스, 알트코인을 분석할 수 있는 웹 앱입니다.',
+                imageUrl: 'https://placehold.co/600x400/14b8a6/0f172a?text=Crypto+Flow+Studio',
+                demoUrl: 'https://alibowbow.github.io/bitdomalt'
             }
 
         ];


### PR DESCRIPTION
### Motivation
- Add two new portfolio entries to the projects list so the site can showcase the "나스닥101문" and "크립토 플로우 스튜디오" web apps.

### Description
- Inserted two project objects (`proj11`, `proj12`) into the projects array in `index.html` with `title`, `description`, `imageUrl`, and `demoUrl` (`https://service-101-lite-576760788290.us-west1.run.app/` and `https://alibowbow.github.io/bitdomalt`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b61a055014832b881c50e37d73223e)