### PR TITLE
Update Korea trip planner demo link to Vercel deployment

### DIFF
--- a/index.html
+++ b/index.html
@@ -1090,7 +1090,7 @@
                 title: '대한민국 여행 플래너',
                 description: 'AI와 함께 대한민국 여행 계획을 세워보세요. 맞춤형 일정과 추천 장소를 제공합니다.',
                 imageUrl: 'https://placehold.co/600x400/14b8a6/0f172a?text=Korea+Trip+Planner',
-                demoUrl: 'https://g.co/gemini/share/00a92e67b463'
+                demoUrl: 'https://koreaplanner.vercel.app'
             },
             {
                 id: 'proj8',


### PR DESCRIPTION
### Motivation
- Replace the outdated Gemini share URL with the live Vercel deployment so the "대한민국 여행 플래너" demo points to the correct site.

### Description
- Updated `proj7.demoUrl` in `index.html` from `https://g.co/gemini/share/00a92e67b463` to `https://koreaplanner.vercel.app`.

### Testing
- Performed local repository checks and commit by running `git -C /workspace/daropo status --short`, `git -C /workspace/daropo add index.html && git -C /workspace/daropo commit -m "Update Korea trip planner demo link"`, and `git -C /workspace/daropo show --stat --oneline -1`, and no automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd06a0c330832bb5472d1a7cdfe719)